### PR TITLE
Added test timeout and self-terminating tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,15 @@
 var assert = require('assert');
 var headless = require('../index');
 
+setTimeout(function() {
+  throw new Error('Timeout 2 seconds. You don\'t have xvfb installed or something else is seriously wrong.');
+}, 2000);
+
 headless(function(err, child, servernum) {
-	assert.equal(err, null);
-	assert.equal(typeof(child), 'object');
-	assert.equal(typeof(child.kill), 'function');
-	assert.equal(typeof(servernum), 'number');
+  assert.equal(err, null);
+  assert.equal(typeof(child), 'object');
+  assert.equal(typeof(child.kill), 'function');
+  assert.equal(typeof(servernum), 'number');
+  child.kill();
+  child.on('exit', process.exit);
 });


### PR DESCRIPTION
Included in this pull request:
- 2 second timeout for test suite
- Added self-terminating test

In an attempt to get [substack/testling](https://github.com/substack/testling/) to run, I am inspecting the modules it depends on.

As it turns out, I did not have `xvfb` installed on my machine which caused me to miss the assertions ever get made. After installing `xvfb`, I verified the assertions were running but the process still wasn't terminating. As a result, I added some self-terminating logic. As a gesture of good faith, I added in a test timeout for future brave lost souls.
