### PR TITLE
Added preinstall check for Xvfb

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Headless is a Node.js wrapper for Xvfb, the virtual framebuffer",
   "version": "0.1.1",
   "scripts": {
+    "preinstall": "test -n \"$(which Xvfb)\" || (echo 'Xvfb not found. Please install it and add it to your PATH.' && exit 1)",
     "test": "node test/test.js"
   },
   "repository": {


### PR DESCRIPTION
When going to sleep last night, I realized we can do even better for all `node_modules` which depend on this. I have added a `preinstall` script which verifies that `Xvfb` is installed and errors out otherwise.

``` sh
$ npm install

> headless@0.1.1 preinstall /home/todd/github/node-headless
> test -n "$(which Xvfb)" || (echo 'Xvfb not found. Please install it and add it to your PATH.' && exit 1)

Xvfb not found. Please install it and add it to your PATH.
npm ERR! headless@0.1.1 preinstall: `test -n "$(which Xvfb)" || (echo 'Xvfb not found. Please install it and add it to your PATH.' && exit 1)`
npm ERR! `sh "-c" "test -n \"$(which Xvfb)\" || (echo 'Xvfb not found. Please install it and add it to your PATH.' && exit 1)"` failed with 1

```

If you do merge this one, can you update the version and publish to `npm`?

Thanks a bunch!
