### PR TITLE
revert xvfb check

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Headless is a Node.js wrapper for Xvfb, the virtual framebuffer",
   "version": "0.1.2",
   "scripts": {
-    "preinstall": "test -n \"$(which Xvfb)\" || (echo 'Xvfb not found. Please install it and add it to your PATH.' && exit 1)",
     "test": "node test/test.js"
   },
   "repository": {


### PR DESCRIPTION
This module e.g. is used by browser-launcher, which until now worked for people who didn't have a linux system as long as they didn't use the headless option. With introduction of the xvfb preinstall check (in a patch version..) browser-launcher won't install on my machine anymore.
