### PR TITLE
allow Xvfb child process to be killed

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = function headless(startnum, callback) {
     // assume starting Xvfb takes less than 500 ms and continue if it hasn't
     // exited during that time
     var timeout = setTimeout(function() {
+      childProcess.removeAllListeners('exit');
       callback(null, childProcess, servernum);
     }, 500);
 


### PR DESCRIPTION
Remove the "exit" handler event when Xvfb has successfully started
up. Otherwise, it is impossible to kill the Xvfb process with
`childProcess.kill()` since it will just get restarted by the
"exit" event handler.
