### PR TITLE
Added check for enoent error

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,18 +29,38 @@ module.exports = function headless(startnum, callback) {
     // assume starting Xvfb takes less than 500 ms and continue if it hasn't
     // exited during that time
     var timeout = setTimeout(function() {
-      childProcess.removeListener('exit', onExit);
+      cleanUpListeners();
       callback(null, childProcess, servernum);
     }, 500);
 
     function onExit() {
       clearTimeout(timeout);
+      cleanUpListeners();
+
       servernum++;
       headless(servernum, callback);
+    }
+
+    function onError (err) {
+      clearTimeout(timeout);
+      cleanUpListeners();
+
+      if (~err.message.indexOf('ENOENT')) {
+        callback(new Error('Xvfb is not installed or is not in your $PATH'));
+      } else {
+        callback(err);
+      }
     }
 
     // if Xvfb exits prematurely the servernum wasn't valid.
     // Happens if there's already an X-server running on @servernum but no file was created in /tmp
     childProcess.once('exit', onExit);
+    // if Xvfb is not installed, the childProcess will emit an ENOENT error
+    childProcess.once('error', onError);
+
+    function cleanUpListeners() {
+      childProcess.removeListener('exit', onExit);
+      childProcess.removeListener('error', onError);
+    }
   });
 }


### PR DESCRIPTION
This package is used by [browser-launcher](https://github.com/substack/browser-launcher) to launch a browser headlessly. When run on OSX, which doesn't have Xvfb installed by default, the call to spawn triggers an error event which is unhanded and displays this useless output:

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: spawn ENOENT
    at errnoException (child_process.js:980:11)
    at Process.ChildProcess._handle.onexit (child_process.js:771:34)
```

Added an listener for "error" that will pass back a useful error message when it can.
